### PR TITLE
Setting urlCurl to empty string shouldn't disable FB & Twitter counts

### DIFF
--- a/jquery.sharrre.js
+++ b/jquery.sharrre.js
@@ -449,7 +449,7 @@
       url = urlJson[name].replace('{url}', this.options.buttons[name].url);
     }
     //console.log('name : ' + name + ' - url : '+url); //debug
-    if(url != '' && self.options.urlCurl !== ''){  //urlCurl = '' if you don't want to used PHP script but used social button
+    if(url != ''){  //urlCurl = '' if you don't want to used PHP script but used social button
       $.getJSON(url, function(json){
         if(typeof json.count !== "undefined"){  //GooglePlus, Stumbleupon, Twitter and Digg
           var temp = json.count + '';


### PR DESCRIPTION
Per the docs, setting urlCurl to an empty string should only affect Google+ and the other networks that rely on it — but instead doing so disables count for Facebook, Twitter, and everything else.

Without delving too deeply into your code, it appears that this simple patch fixes the issue.
