### PR TITLE
Fix GooglePlus parsing to return an integer without punctuation; Add Twitter Follow option.

### DIFF
--- a/sharrre.php
+++ b/sharrre.php
@@ -20,7 +20,7 @@
       $filtered = $domxpath->query("//div[@id='aggregateCount']");
       if (isset($filtered->item(0)->nodeValue))
       {
-        $json['count'] = str_replace('>', '', $filtered->item(0)->nodeValue);
+        $json['count'] = preg_replace('/[^0-9]/', '', $filtered->item(0)->nodeValue);
       }
     }
     else if($type == 'stumbleupon'){

--- a/sharrre.php
+++ b/sharrre.php
@@ -20,7 +20,15 @@
       $filtered = $domxpath->query("//div[@id='aggregateCount']");
       if (isset($filtered->item(0)->nodeValue))
       {
-        $json['count'] = preg_replace('/[^0-9]/', '', $filtered->item(0)->nodeValue);
+        $json['count'] = str_replace('>', '', $filtered->item(0)->nodeValue);
+        if (strpos($json['count'], 'k') !== false)
+          $json['count'] = (float)$json['count'] * 1000;
+        
+        if (strpos($json['count'], 'm') !== false)
+          $json['count'] = (float)$json['count'] * 1000000;
+
+
+        $json['count'] = preg_replace('/[^0-9]/', '', $json['count']);
       }
     }
     else if($type == 'stumbleupon'){

--- a/sharrre.php
+++ b/sharrre.php
@@ -10,25 +10,8 @@
     if($type == 'googlePlus'){  //source http://www.helmutgranda.com/2011/11/01/get-a-url-google-count-via-php/
       $content = parse("https://plusone.google.com/u/0/_/+1/fastbutton?url=".$url."&count=true");
       
-      $dom = new DOMDocument;
-      $dom->preserveWhiteSpace = false;
-      @$dom->loadHTML($content);
-      $domxpath = new DOMXPath($dom);
-      $newDom = new DOMDocument;
-      $newDom->formatOutput = true;
-      
-      $filtered = $domxpath->query("//div[@id='aggregateCount']");
-      if (isset($filtered->item(0)->nodeValue))
-      {
-        $json['count'] = str_replace('>', '', $filtered->item(0)->nodeValue);
-        if (strpos($json['count'], 'k') !== false)
-          $json['count'] = (float)$json['count'] * 1000;
-        
-        if (strpos($json['count'], 'm') !== false)
-          $json['count'] = (float)$json['count'] * 1000000;
-
-
-        $json['count'] = preg_replace('/[^0-9]/', '', $json['count']);
+      if (preg_match("/window\.__SSR\s=\s\{c:\s([0-9]+)\.0/", $content, $matches)) {
+        $json['count'] = $matches[1];
       }
     }
     else if($type == 'stumbleupon'){

--- a/twitter-follow.html
+++ b/twitter-follow.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+	<meta charset="UTF-8">
+	<title>Sharrre.com</title>
+  <meta name="description" content="Sharrre" />
+  <script src="http://code.jquery.com/jquery-1.7.min.js"></script>
+  <script src="jquery.sharrre.js"></script>
+  <script>
+  $(function(){
+    $('#shareme').sharrre({
+      share: {
+        googlePlus: true,
+        facebook: true,
+        twitter: true,
+        digg: false,
+        delicious: false
+      },
+      enableTracking: true,
+      buttons: {
+        googlePlus: {size: 'medium', annotation:'bubble'},
+        facebook: {layout: 'button_count', width: '75', height: '100'},
+        twitter: {count: 'horizontal', action: 'follow', screenName: "ciandt_BR", lang: 'en', size: 'medium', showCount: true, showScreenName: false}/*,
+        digg: {type: 'DiggMedium'},
+        delicious: {size: 'tall'}*/
+      },
+      hover: function(api, options){
+        $(api.element).find('.buttons').show();
+      },
+      hide: function(api, options){
+        $(api.element).find('.buttons').hide();
+      }
+    });
+  });
+  </script>
+  <style type="text/css">
+    #demo3{
+      float:left;
+      margin:63px 33% 0 33%;
+    }
+    #shareme .box{
+      float:left;
+      margin:5% 8% 0 8%;
+      width:100%;
+    }
+    #shareme .box a{
+      color:#404040;
+      text-shadow: 0 1px 1px rgba(167,167,167,.4);
+    }
+    #shareme .box a:hover{
+      text-decoration:none;
+    }
+    #shareme .count {
+      font-weight:bold;
+      font-size:50px;
+      float:left;
+      border-right:2px solid #57b8d1;
+      line-height:40px;
+      padding-right:10px
+    }
+    #shareme .share {
+      float:left;
+      margin-left:10px;
+      font-size:20px;
+      width:82px;
+    }
+    #shareme .buttons {
+      position: absolute;
+      width:170px;
+      height: 55px;
+      background-color:#fff;
+      border: 1px solid rgba(0,0,0,.2);
+      padding:10px;
+      -webkit-box-shadow: 0 1px 2px rgba(0,0,0,.1);
+      -moz-box-shadow: 0 1px 2px rgba(0,0,0,.1);
+      box-shadow: 0 1px 2px rgba(0,0,0,.1);
+    }
+    #shareme .button {
+      /*float:left;*/
+      max-width:80px;
+      margin:0 5px 0 0;
+    }
+
+    #shareme .button.googleplus,
+    #shareme .button.facebook {
+      float: left;
+    }
+
+    #shareme .facebook {
+      margin:0 4px 0 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>Sharrre demo</h1>
+  <div id="demo3">
+    <div id="shareme" data-url="http://www.ciandt.com/" data-text="Make your sharing widget with Sharrre (jQuery Plugin)" data-title="share this page"></div>
+  </div>
+<script>
+
+</script>
+
+</body>
+</html>
+


### PR DESCRIPTION
The logic for parsing GooglePlus result inside sharrre.php return a number with punctuation when the count is greather than 1000. 

Before fix:
```
{"url":"http://www.ciandt.com","count":"3.169"}
```

After fix:
```
{"url":"http://www.ciandt.com","count":"3169"}
```

Then, when the js code parseInt() it, the results gets wrong, since, for example, 3.169 (more than 3 thousand) gets converted to integer 3.

```
        if(typeof json.count !== "undefined"){  //GooglePlus, Stumbleupon, Twitter, Pinterest and Digg
          var temp = json.count + '';
          temp = temp.replace('\u00c2\u00a0', '');  //remove google plus special chars
          count += parseInt(temp, 10);
        }
```