### PR TITLE
Updated URLS in the urlJson object

### DIFF
--- a/jquery.sharrre.js
+++ b/jquery.sharrre.js
@@ -105,13 +105,13 @@
     //old method facebook: "http://graph.facebook.com/?id={url}&callback=?",
     //facebook : "http://api.ak.facebook.com/restserver.php?v=1.0&method=links.getStats&urls={url}&format=json"
     
-    twitter: "http://cdn.api.twitter.com/1/urls/count.json?url={url}&callback=?",
+    twitter: "https://cdn.api.twitter.com/1/urls/count.json?url={url}&callback=?",
     digg: "http://services.digg.com/2.0/story.getInfo?links={url}&type=javascript&callback=?",
     delicious: 'http://feeds.delicious.com/v2/json/urlinfo/data?url={url}&callback=?',
     //stumbleupon: "http://www.stumbleupon.com/services/1.01/badge.getinfo?url={url}&format=jsonp&callback=?",
     stumbleupon: "",
-    linkedin: "http://www.linkedin.com/countserv/count/share?format=jsonp&url={url}&callback=?",
-    pinterest: "http://api.pinterest.com/v1/urls/count.json?url={url}&callback=?"
+    linkedin: "https://www.linkedin.com/countserv/count/share?format=jsonp&url={url}&callback=?",
+    pinterest: "https://api.pinterest.com/v1/urls/count.json?url={url}&callback=?"
   },
   /* Load share buttons asynchronously
   ================================================== */


### PR DESCRIPTION
It was throwing errors on a site that was SSL secured, so I updated the code to use https instead.  Twitter, LinkedIn and Pinterest have been tested and work and those are the ones I changed.
I didn't change the urls for digg or delicious because they didn't work with the quick test I did.