### PR TITLE
Fix #232: gapi.plusone undefined

### DIFF
--- a/jquery.sharrre.js
+++ b/jquery.sharrre.js
@@ -124,7 +124,7 @@
         lang: self.options.buttons.googlePlus.lang
       };
       var loading = 0;
-      if(typeof gapi === 'undefined' && loading == 0){
+      if((typeof gapi === 'undefined' || typeof gapi.plusone === 'undefined') && loading == 0){
         loading = 1;
         (function() {
           var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;


### PR DESCRIPTION
explicitly check for the google plusone api being present (there already may be other google apis around)