### PR TITLE
added an empty buttons obj on the defaults obj

### DIFF
--- a/src/js/jquery.sharrre.js
+++ b/src/js/jquery.sharrre.js
@@ -12,6 +12,7 @@
         defaults = {
             className: 'sharrre',
             share: {},
+            buttons: {},
             shareTotal: 0,
             template: '',
             title: '',


### PR DESCRIPTION
This fixes a bug that causes an error on line 62 ( self.platforms[name] = SharrrePlatform.get(name, self.options.buttons[name]) ) if the initiation script doesn't include the buttons object. After this change, it can be safely omitted if not needed.